### PR TITLE
Allow missing :controller parameter when determining context

### DIFF
--- a/lib/cancan_namespace/controller_additions.rb
+++ b/lib/cancan_namespace/controller_additions.rb
@@ -9,7 +9,7 @@ module CanCanNamespace
     end
 
     def get_context
-      modules = request.path_parameters[:controller].sub("Controller", "").underscore.split('/')
+      modules = request.path_parameters[:controller].to_s.sub("Controller", "").underscore.split('/')
       if modules.size > 1
         modules[0..-2].map(&:singularize).join('__')
       else


### PR DESCRIPTION
There seem to be ways to accomplish that via Rails Routing